### PR TITLE
Datacache on batch func

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -26,3 +26,8 @@ func (c *NoCache[K, V]) Delete(context.Context, K) bool { return false }
 
 // Clear is a NOOP
 func (c *NoCache[K, V]) Clear() { return }
+
+type DataCache[K comparable, V any] interface {
+	Get(context.Context, K) (V, bool)
+	Set(context.Context, K, V)
+}

--- a/example/lru_cache/golang_lru_test.go
+++ b/example/lru_cache/golang_lru_test.go
@@ -55,11 +55,11 @@ func ExampleGolangLRU() {
 		5: {ID: 5, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
 	}
 
-	batchFunc := func(_ context.Context, keys []int) []*dataloader.Result[*User] {
+	batchFunc := func(_ context.Context, keys dataloader.Keys[int]) []*dataloader.Result[*User] {
 		var results []*dataloader.Result[*User]
 		// do some pretend work to resolve keys
 		for _, k := range keys {
-			results = append(results, &dataloader.Result[*User]{Data: m[k]})
+			results = append(results, &dataloader.Result[*User]{Data: m[k.Raw()]})
 		}
 		return results
 	}

--- a/example/no_cache/no_cache_test.go
+++ b/example/no_cache/no_cache_test.go
@@ -19,11 +19,11 @@ func ExampleNoCache() {
 		5: {ID: 5, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
 	}
 
-	batchFunc := func(_ context.Context, keys []int) []*dataloader.Result[*User] {
+	batchFunc := func(_ context.Context, keys dataloader.Keys[int]) []*dataloader.Result[*User] {
 		var results []*dataloader.Result[*User]
 		// do some pretend work to resolve keys
 		for _, k := range keys {
-			results = append(results, &dataloader.Result[*User]{Data: m[k]})
+			results = append(results, &dataloader.Result[*User]{Data: m[k.Raw()]})
 		}
 		return results
 	}

--- a/example/ttl_cache/go_cache_test.go
+++ b/example/ttl_cache/go_cache_test.go
@@ -59,11 +59,11 @@ func ExampleTTLCache() {
 		5: {ID: 5, FirstName: "John", LastName: "Smith", Email: "john@example.com"},
 	}
 
-	batchFunc := func(_ context.Context, keys []int) []*dataloader.Result[*User] {
+	batchFunc := func(_ context.Context, keys dataloader.Keys[int]) []*dataloader.Result[*User] {
 		var results []*dataloader.Result[*User]
 		// do some pretend work to resolve keys
 		for _, k := range keys {
-			results = append(results, &dataloader.Result[*User]{Data: m[k]})
+			results = append(results, &dataloader.Result[*User]{Data: m[k.Raw()]})
 		}
 		return results
 	}

--- a/keys.go
+++ b/keys.go
@@ -1,0 +1,47 @@
+package dataloader
+
+import (
+	"context"
+)
+
+type Key[K comparable] interface {
+	Raw() K
+	Context() context.Context
+}
+
+type Keys[K comparable] []Key[K]
+
+type ckey[K comparable] struct {
+	root K
+	ctx  context.Context
+}
+
+func (c *ckey[K]) Raw() K {
+	return c.root
+}
+
+func (c *ckey[K]) Context() context.Context {
+	return c.ctx
+}
+
+func ContextKey[K comparable](ctx context.Context, key K) Key[K] {
+	return &ckey[K]{root: key, ctx: ctx}
+}
+
+func ContextKeys[K comparable](ctx context.Context, keys []K) Keys[K] {
+	result := make(Keys[K], len(keys))
+	for i := range keys {
+		result[i] = ContextKey(ctx, keys[i])
+	}
+
+	return result
+}
+
+func (k Keys[K]) Raw() []K {
+	result := make([]K, len(k))
+	for i := range k {
+		result[i] = k[i].Raw()
+	}
+
+	return result
+}

--- a/trace.go
+++ b/trace.go
@@ -11,27 +11,27 @@ type TraceBatchFinishFunc[V any] func([]*Result[V])
 // Tracer is an interface that may be used to implement tracing.
 type Tracer[K comparable, V any] interface {
 	// TraceLoad will trace the calls to Load.
-	TraceLoad(ctx context.Context, key K) (context.Context, TraceLoadFinishFunc[V])
+	TraceLoad(ctx context.Context, key Key[K]) (context.Context, TraceLoadFinishFunc[V])
 	// TraceLoadMany will trace the calls to LoadMany.
-	TraceLoadMany(ctx context.Context, keys []K) (context.Context, TraceLoadManyFinishFunc[V])
+	TraceLoadMany(ctx context.Context, keys Keys[K]) (context.Context, TraceLoadManyFinishFunc[V])
 	// TraceBatch will trace data loader batches.
-	TraceBatch(ctx context.Context, keys []K) (context.Context, TraceBatchFinishFunc[V])
+	TraceBatch(ctx context.Context, keys Keys[K]) (context.Context, TraceBatchFinishFunc[V])
 }
 
 // NoopTracer is the default (noop) tracer
 type NoopTracer[K comparable, V any] struct{}
 
 // TraceLoad is a noop function
-func (NoopTracer[K, V]) TraceLoad(ctx context.Context, key K) (context.Context, TraceLoadFinishFunc[V]) {
+func (NoopTracer[K, V]) TraceLoad(ctx context.Context, key Key[K]) (context.Context, TraceLoadFinishFunc[V]) {
 	return ctx, func(Thunk[V]) {}
 }
 
 // TraceLoadMany is a noop function
-func (NoopTracer[K, V]) TraceLoadMany(ctx context.Context, keys []K) (context.Context, TraceLoadManyFinishFunc[V]) {
+func (NoopTracer[K, V]) TraceLoadMany(ctx context.Context, keys Keys[K]) (context.Context, TraceLoadManyFinishFunc[V]) {
 	return ctx, func(ThunkMany[V]) {}
 }
 
 // TraceBatch is a noop function
-func (NoopTracer[K, V]) TraceBatch(ctx context.Context, keys []K) (context.Context, TraceBatchFinishFunc[V]) {
+func (NoopTracer[K, V]) TraceBatch(ctx context.Context, keys Keys[K]) (context.Context, TraceBatchFinishFunc[V]) {
 	return ctx, func(result []*Result[V]) {}
 }

--- a/trace/opentracing/trace.go
+++ b/trace/opentracing/trace.go
@@ -9,11 +9,13 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+var _ dataloader.Tracer[string, string] = &Tracer[string, string]{}
+
 // Tracer implements a tracer that can be used with the Open Tracing standard.
 type Tracer[K comparable, V any] struct{}
 
 // TraceLoad will trace a call to dataloader.LoadMany with Open Tracing.
-func (Tracer[K, V]) TraceLoad(ctx context.Context, key K) (context.Context, dataloader.TraceLoadFinishFunc[V]) {
+func (Tracer[K, V]) TraceLoad(ctx context.Context, key dataloader.Key[K]) (context.Context, dataloader.TraceLoadFinishFunc[V]) {
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: load")
 
 	span.SetTag("dataloader.key", fmt.Sprintf("%v", key))
@@ -24,10 +26,10 @@ func (Tracer[K, V]) TraceLoad(ctx context.Context, key K) (context.Context, data
 }
 
 // TraceLoadMany will trace a call to dataloader.LoadMany with Open Tracing.
-func (Tracer[K, V]) TraceLoadMany(ctx context.Context, keys []K) (context.Context, dataloader.TraceLoadManyFinishFunc[V]) {
+func (Tracer[K, V]) TraceLoadMany(ctx context.Context, keys dataloader.Keys[K]) (context.Context, dataloader.TraceLoadManyFinishFunc[V]) {
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: loadmany")
 
-	span.SetTag("dataloader.keys", fmt.Sprintf("%v", keys))
+	span.SetTag("dataloader.keys", fmt.Sprintf("%v", keys.Raw()))
 
 	return spanCtx, func(thunk dataloader.ThunkMany[V]) {
 		span.Finish()
@@ -35,10 +37,10 @@ func (Tracer[K, V]) TraceLoadMany(ctx context.Context, keys []K) (context.Contex
 }
 
 // TraceBatch will trace a call to dataloader.LoadMany with Open Tracing.
-func (Tracer[K, V]) TraceBatch(ctx context.Context, keys []K) (context.Context, dataloader.TraceBatchFinishFunc[V]) {
+func (Tracer[K, V]) TraceBatch(ctx context.Context, keys dataloader.Keys[K]) (context.Context, dataloader.TraceBatchFinishFunc[V]) {
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, "Dataloader: batch")
 
-	span.SetTag("dataloader.keys", fmt.Sprintf("%v", keys))
+	span.SetTag("dataloader.keys", fmt.Sprintf("%v", keys.Raw()))
 
 	return spanCtx, func(results []*dataloader.Result[V]) {
 		span.Finish()

--- a/trace/otel/trace.go
+++ b/trace/otel/trace.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+var _ dataloader.Tracer[string, string] = &Tracer[string, string]{}
+
 // Tracer implements a tracer that can be used with the Open Tracing standard.
 type Tracer[K comparable, V any] struct {
 	tr trace.Tracer
@@ -28,10 +30,10 @@ func (t *Tracer[K, V]) Tracer() trace.Tracer {
 }
 
 // TraceLoad will trace a call to dataloader.LoadMany with Open Tracing.
-func (t Tracer[K, V]) TraceLoad(ctx context.Context, key K) (context.Context, dataloader.TraceLoadFinishFunc[V]) {
+func (t Tracer[K, V]) TraceLoad(ctx context.Context, key dataloader.Key[K]) (context.Context, dataloader.TraceLoadFinishFunc[V]) {
 	spanCtx, span := t.Tracer().Start(ctx, "Dataloader: load")
 
-	span.SetAttributes(attribute.String("dataloader.key", fmt.Sprintf("%v", key)))
+	span.SetAttributes(attribute.String("dataloader.key", fmt.Sprintf("%v", key.Raw())))
 
 	return spanCtx, func(thunk dataloader.Thunk[V]) {
 		span.End()
@@ -39,10 +41,10 @@ func (t Tracer[K, V]) TraceLoad(ctx context.Context, key K) (context.Context, da
 }
 
 // TraceLoadMany will trace a call to dataloader.LoadMany with Open Tracing.
-func (t Tracer[K, V]) TraceLoadMany(ctx context.Context, keys []K) (context.Context, dataloader.TraceLoadManyFinishFunc[V]) {
+func (t Tracer[K, V]) TraceLoadMany(ctx context.Context, keys dataloader.Keys[K]) (context.Context, dataloader.TraceLoadManyFinishFunc[V]) {
 	spanCtx, span := t.Tracer().Start(ctx, "Dataloader: loadmany")
 
-	span.SetAttributes(attribute.String("dataloader.keys", fmt.Sprintf("%v", keys)))
+	span.SetAttributes(attribute.String("dataloader.keys", fmt.Sprintf("%v", keys.Raw())))
 
 	return spanCtx, func(thunk dataloader.ThunkMany[V]) {
 		span.End()
@@ -50,10 +52,10 @@ func (t Tracer[K, V]) TraceLoadMany(ctx context.Context, keys []K) (context.Cont
 }
 
 // TraceBatch will trace a call to dataloader.LoadMany with Open Tracing.
-func (t Tracer[K, V]) TraceBatch(ctx context.Context, keys []K) (context.Context, dataloader.TraceBatchFinishFunc[V]) {
+func (t Tracer[K, V]) TraceBatch(ctx context.Context, keys dataloader.Keys[K]) (context.Context, dataloader.TraceBatchFinishFunc[V]) {
 	spanCtx, span := t.Tracer().Start(ctx, "Dataloader: batch")
 
-	span.SetAttributes(attribute.String("dataloader.keys", fmt.Sprintf("%v", keys)))
+	span.SetAttributes(attribute.String("dataloader.keys", fmt.Sprintf("%v", keys.Raw())))
 
 	return spanCtx, func(results []*dataloader.Result[V]) {
 		span.End()


### PR DESCRIPTION
1. Use Key[K]/Keys[K] in BatchFunc and Loader for save original context
2. Add DataCache[K, V] for wrap batchFunc and use cache on real data. It's need for use not in memory caches, like redis.